### PR TITLE
align jenkins reverse proxy configuration to official one

### DIFF
--- a/proxy.conf
+++ b/proxy.conf
@@ -15,10 +15,15 @@ server {
     }
 
     location /jenkins {
-        proxy_pass    http://jenkins:8080;
-        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass          http://jenkins:8080;
+        proxy_set_header    Host $http_host;
         proxy_set_header    X-Real-IP $remote_addr;
-        proxy_set_header    Host $host;
+        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header    X-Forwarded-Proto $scheme;
+        proxy_set_header    X-Forwarded-Host $http_host;
+        proxy_redirect      off;
+        proxy_http_version  1.1;
+        proxy_request_buffering off;
     }
 
     location /ssp {


### PR DESCRIPTION
this allows to handle proper redirects for custom ports, solves jenkins problem with well known problem related to *You reverse proxy configuration is broken*

env.config
```bash
export PROXY_PORT="8002"
export PROXY_HOST="localhost:${PROXY_PORT}"
```